### PR TITLE
feat: scaffold project structure for TASK-D-02

### DIFF
--- a/cmd/vigenda/main.go
+++ b/cmd/vigenda/main.go
@@ -1,0 +1,7 @@
+// Package main is the entry point of the Vigenda application.
+// It handles the main function and Cobra CLI configuration.
+package main
+
+func main() {
+	// TODO: Implement Cobra CLI setup
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,3 @@
+// Package config provides logic for reading and managing the
+// config.toml configuration file for the Vigenda application.
+package config

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -1,0 +1,3 @@
+// Package database handles the connection to the SQLite database
+// and the execution of database migrations.
+package database

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1,0 +1,3 @@
+// Package models defines all Go structs used in the Vigenda application.
+// These structs represent entities like Task, Lesson, Student, Class, etc.
+package models

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -1,0 +1,3 @@
+// Package repository implements the Repository Pattern for data access.
+// It contains functions for performing SQL queries against the database.
+package repository

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,0 +1,3 @@
+// Package service contains the business logic of the Vigenda application.
+// It acts as an intermediary between the CLI/TUI and the repository layer.
+package service

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1,0 +1,3 @@
+// Package tui implements the Text User Interface (TUI) for the Vigenda application.
+// It uses the Bubble Tea library and its components to create an interactive CLI experience.
+package tui


### PR DESCRIPTION
Creates the complete Go project directory structure as per Artefact 3.1. Adds empty Go files with header comments describing their purpose within each package.