### PR TITLE
WIP: Implement bug monitoring and task creation for errors

### DIFF
--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -37,13 +37,16 @@ type SubjectRepository interface {
 
 // Outras interfaces de repositório (TaskRepository, ClassRepository, etc.) seriam definidas aqui.
 // Por exemplo:
-//
-// type TaskRepository interface {
-//    CreateTask(ctx context.Context, task *models.Task) (int64, error)
-//    GetTaskByID(ctx context.Context, id int64) (*models.Task, error)
-//    // ... outros métodos
-// }
-//
+
+type TaskRepository interface {
+	CreateTask(ctx context.Context, task *models.Task) (int64, error)
+	GetTaskByID(ctx context.Context, id int64) (*models.Task, error)
+	GetTasksByClassID(ctx context.Context, classID int64) ([]models.Task, error) // Added for listing tasks
+	GetAllTasks(ctx context.Context) ([]models.Task, error)                       // New method
+	MarkTaskCompleted(ctx context.Context, taskID int64) error                   // Added for completing tasks
+	// ... outros métodos
+}
+
 // type ClassRepository interface {
 //    CreateClass(ctx context.Context, class *models.Class) (int64, error)
 //    GetClassByID(ctx context.Context, id int64) (*models.Class, error)

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -13,6 +13,7 @@ import (
 type TaskService interface {
 	CreateTask(ctx context.Context, title, description string, classID *int64, dueDate *time.Time) (models.Task, error)
 	ListActiveTasksByClass(ctx context.Context, classID int64) ([]models.Task, error)
+	ListAllActiveTasks(ctx context.Context) ([]models.Task, error) // New method for listing all tasks
 	MarkTaskAsCompleted(ctx context.Context, taskID int64) error
 }
 

--- a/internal/service/stubs.go
+++ b/internal/service/stubs.go
@@ -54,6 +54,24 @@ func (s *stubTaskService) MarkTaskAsCompleted(ctx context.Context, taskID int64)
 	return s.taskRepo.MarkTaskCompleted(ctx, taskID) // Assuming stub repo has this
 }
 
+func (s *stubTaskService) ListAllActiveTasks(ctx context.Context) ([]models.Task, error) {
+	fmt.Printf("[StubTaskService] ListAllActiveTasks called\n")
+	// In a real stub, you might want to mock this further or provide specific stub data.
+	// For now, just pass through to the repository stub.
+	allTasks, err := s.taskRepo.GetAllTasks(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// The service layer is responsible for filtering active tasks
+	activeTasks := []models.Task{}
+	for _, task := range allTasks {
+		if !task.IsCompleted {
+			activeTasks = append(activeTasks, task)
+		}
+	}
+	return activeTasks, nil
+}
+
 // StubClassService
 type stubClassService struct {
 	classRepo *repository.StubClassRepository

--- a/internal/service/task_service.go
+++ b/internal/service/task_service.go
@@ -2,33 +2,155 @@ package service
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"os"
 	"time"
 	"vigenda/internal/models"
+	"vigenda/internal/repository" // Added import
 )
 
-// Implementação do TaskService (exemplo, precisa ser preenchido)
+// Implementação do TaskService
 type taskServiceImpl struct {
-	// Adicionar dependências de repositório aqui
+	repo repository.TaskRepository
 }
 
 // NewTaskService cria uma nova instância de TaskService.
-func NewTaskService(/* dependências do repositório */) TaskService {
+func NewTaskService(repo repository.TaskRepository) TaskService {
 	return &taskServiceImpl{
-		// inicializar dependências
+		repo: repo,
 	}
 }
 
+// logError é um helper para logar um erro e retornar.
+// No futuro, isso pode ser expandido para usar um logger mais sofisticado.
+func logError(format string, args ...interface{}) {
+	// Simplesmente imprime para stderr por enquanto.
+	// Em uma aplicação real, usaríamos um pacote de logging.
+	fmt.Fprintf(os.Stderr, "ERROR: "+format+"\n", args...)
+}
+
+// handleErrorAndCreateBugTask lida com um erro, loga-o e tenta criar uma tarefa de bug.
+// Note que a criação da tarefa de bug em si pode falhar, o que não é tratado recursivamente aqui para evitar loops.
+func (s *taskServiceImpl) handleErrorAndCreateBugTask(ctx context.Context, originalError error, bugTitlePrefix string, bugDescriptionArgs ...interface{}) {
+	logError("%s: %v", bugTitlePrefix, originalError)
+
+	// Tenta criar uma tarefa para o bug.
+	// O UserID para tarefas de sistema/bug pode ser um valor especial (ex: 0 ou um ID de usuário de sistema configurado)
+	// ou podemos omiti-lo se o modelo permitir. Assumindo que UserID 0 é para tarefas do sistema.
+	// ClassID pode ser nil se o bug não for específico de uma turma.
+	bugTitle := fmt.Sprintf("[BUG] %s", bugTitlePrefix)
+	bugDescription := fmt.Sprintf("Error encountered: %v. Details: %s", originalError, fmt.Sprintf(bugDescriptionArgs[0].(string), bugDescriptionArgs[1:]...))
+
+	// O UserID para tarefas de sistema/bug pode ser um valor especial (ex: 0 ou um ID de usuário de sistema configurado)
+	// Usaremos UserID 0 para tarefas do sistema. ClassID pode ser nil.
+	systemUserID := int64(0)
+	bugTask := models.Task{
+		UserID:      systemUserID,
+		ClassID:     nil, // Bugs geralmente não são específicos de uma turma, a menos que o contexto sugira
+		Title:       bugTitle,
+		Description: bugDescription,
+		IsCompleted: false,
+	}
+
+	_, creationErr := s.repo.CreateTask(ctx, &bugTask)
+	if creationErr != nil {
+		// Log an even more critical error if creating the bug task itself fails.
+		logError("CRITICAL: Failed to create bug task for '%s': %v. Original error: %v", bugTitle, creationErr, originalError)
+	} else {
+		logError("SYSTEM: Bug task created successfully for: %s", bugTitle)
+	}
+}
+
+// CreateTaskInternal is used by handleErrorAndCreateBugTask to avoid recursive bug reporting.
+// It directly calls the repository without the surrounding error handling that might create another bug task.
+// For normal operations, use CreateTask.
+func (s *taskServiceImpl) createTaskInternal(ctx context.Context, userID int64, classID *int64, title, description string, dueDate *time.Time) (models.Task, error) {
+	task := models.Task{
+		UserID:      userID, // Este deve vir do contexto de autenticação ou similar
+		ClassID:     classID,
+		Title:       title,
+		Description: description,
+		DueDate:     dueDate,
+		IsCompleted: false,
+	}
+
+	id, err := s.repo.CreateTask(ctx, &task)
+	if err != nil {
+		return models.Task{}, fmt.Errorf("repository failed to create task: %w", err)
+	}
+	task.ID = id
+	return task, nil
+}
+
 func (s *taskServiceImpl) CreateTask(ctx context.Context, title, description string, classID *int64, dueDate *time.Time) (models.Task, error) {
-	// TODO: Implementar lógica
-	return models.Task{}, nil
+	if title == "" {
+		err := errors.New("task title cannot be empty")
+		logError("CreateTask validation failed: %v", err) // No bug task for validation errors
+		return models.Task{}, err
+	}
+
+	// Assume UserID 1 for now, in a real app this would come from auth context
+	userID := int64(1)
+	task, err := s.createTaskInternal(ctx, userID, classID, title, description, dueDate)
+	if err != nil {
+		// This is an unexpected error from the internal creation process (e.g., DB error from repo)
+		s.handleErrorAndCreateBugTask(ctx, err, "Task Creation Failure", "Attempted to create task with title '%s'. UserID: %d", title, userID)
+		return models.Task{}, err // Return the original error
+	}
+	return task, nil
 }
 
 func (s *taskServiceImpl) ListActiveTasksByClass(ctx context.Context, classID int64) ([]models.Task, error) {
-	// TODO: Implementar lógica
-	return nil, nil
+	tasks, err := s.repo.GetTasksByClassID(ctx, classID)
+	if err != nil {
+		s.handleErrorAndCreateBugTask(ctx, err, "Task Listing Failure", "Attempted to list tasks for classID %d", classID)
+		return nil, err // Return the original error
+	}
+	// Filter for active tasks (IsCompleted == false)
+	// Though the stub GetTasksByClassID doesn't filter, a real repo might.
+	// Or, the repo method could be GetActiveTasksByClassID. For now, filter here.
+	activeTasks := []models.Task{}
+	for _, task := range tasks {
+		if !task.IsCompleted {
+			activeTasks = append(activeTasks, task)
+		}
+	}
+	return activeTasks, nil
+}
+
+func (s *taskServiceImpl) ListAllActiveTasks(ctx context.Context) ([]models.Task, error) {
+	tasks, err := s.repo.GetAllTasks(ctx) // Assumes GetAllTasks exists in repo
+	if err != nil {
+		s.handleErrorAndCreateBugTask(ctx, err, "Task Listing Failure", "Attempted to list all tasks")
+		return nil, err
+	}
+	activeTasks := []models.Task{}
+	for _, task := range tasks {
+		if !task.IsCompleted {
+			activeTasks = append(activeTasks, task)
+		}
+	}
+	return activeTasks, nil
 }
 
 func (s *taskServiceImpl) MarkTaskAsCompleted(ctx context.Context, taskID int64) error {
-	// TODO: Implementar lógica
+	err := s.repo.MarkTaskCompleted(ctx, taskID)
+	if err != nil {
+		// Consider if "not found" is a bug or an expected error.
+		// For now, let's assume if we try to complete a non-existent task, it's a situation worth logging as a potential bug/issue.
+		s.handleErrorAndCreateBugTask(ctx, err, "Task Completion Failure", "Attempted to complete taskID %d", taskID)
+		return err // Return the original error
+	}
 	return nil
 }
+
+// Adicionar importações necessárias no topo do arquivo:
+// import (
+// 	"context"
+// 	"errors"
+// 	"fmt"
+// 	"os"
+// 	"time"
+// 	"vigenda/internal/models"
+// )

--- a/internal/service/task_service_test.go
+++ b/internal/service/task_service_test.go
@@ -1,0 +1,366 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"strings" // Added import
+	"testing"
+	"vigenda/internal/models"
+	"vigenda/internal/repository"
+
+	_ "github.com/mattn/go-sqlite3" // DB driver
+)
+
+// MockTaskRepository for testing TaskService
+type MockTaskRepository struct {
+	CreateTaskFunc        func(ctx context.Context, task *models.Task) (int64, error)
+	GetTaskByIDFunc       func(ctx context.Context, id int64) (*models.Task, error)
+	GetTasksByClassIDFunc func(ctx context.Context, classID int64) ([]models.Task, error)
+	GetAllTasksFunc       func(ctx context.Context) ([]models.Task, error)
+	MarkTaskCompletedFunc func(ctx context.Context, taskID int64) error
+
+	// Store created bug tasks for verification
+	CreatedBugTasks []models.Task
+}
+
+func (m *MockTaskRepository) CreateTask(ctx context.Context, task *models.Task) (int64, error) {
+	if m.CreateTaskFunc != nil {
+		// Check if this is a bug task being created
+		if task.UserID == 0 && task.Title[0:5] == "[BUG]" {
+			m.CreatedBugTasks = append(m.CreatedBugTasks, *task)
+		}
+		return m.CreateTaskFunc(ctx, task)
+	}
+	return 0, errors.New("CreateTaskFunc not implemented in mock")
+}
+
+func (m *MockTaskRepository) GetTaskByID(ctx context.Context, id int64) (*models.Task, error) {
+	if m.GetTaskByIDFunc != nil {
+		return m.GetTaskByIDFunc(ctx, id)
+	}
+	return nil, errors.New("GetTaskByIDFunc not implemented in mock")
+}
+
+func (m *MockTaskRepository) GetTasksByClassID(ctx context.Context, classID int64) ([]models.Task, error) {
+	if m.GetTasksByClassIDFunc != nil {
+		return m.GetTasksByClassIDFunc(ctx, classID)
+	}
+	return nil, errors.New("GetTasksByClassIDFunc not implemented in mock")
+}
+
+func (m *MockTaskRepository) GetAllTasks(ctx context.Context) ([]models.Task, error) {
+	if m.GetAllTasksFunc != nil {
+		return m.GetAllTasksFunc(ctx)
+	}
+	return nil, errors.New("GetAllTasksFunc not implemented in mock")
+}
+
+func (m *MockTaskRepository) MarkTaskCompleted(ctx context.Context, taskID int64) error {
+	if m.MarkTaskCompletedFunc != nil {
+		return m.MarkTaskCompletedFunc(ctx, taskID)
+	}
+	return errors.New("MarkTaskCompletedFunc not implemented in mock")
+}
+
+func TestTaskService_CreateTask(t *testing.T) {
+	mockRepo := &MockTaskRepository{}
+	taskService := NewTaskService(mockRepo)
+	ctx := context.Background()
+
+	t.Run("successful task creation", func(t *testing.T) {
+		mockRepo.CreatedBugTasks = []models.Task{} // Reset
+		expectedID := int64(1)
+		mockRepo.CreateTaskFunc = func(ctx context.Context, task *models.Task) (int64, error) {
+			return expectedID, nil
+		}
+
+		title := "Test Task"
+		desc := "Test Description"
+		task, err := taskService.CreateTask(ctx, title, desc, nil, nil)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if task.ID != expectedID {
+			t.Errorf("Expected task ID %d, got %d", expectedID, task.ID)
+		}
+		if task.Title != title {
+			t.Errorf("Expected task title %s, got %s", title, task.Title)
+		}
+		if len(mockRepo.CreatedBugTasks) != 0 {
+			t.Errorf("Expected no bug tasks to be created, got %d", len(mockRepo.CreatedBugTasks))
+		}
+	})
+
+	t.Run("repository error on create", func(t *testing.T) {
+		mockRepo.CreatedBugTasks = []models.Task{} // Reset
+		repoError := errors.New("database is down")
+		mockRepo.CreateTaskFunc = func(ctx context.Context, task *models.Task) (int64, error) {
+			// Simulate different behavior for bug task creation vs normal task creation
+			if task.UserID == 0 && task.Title[0:5] == "[BUG]" { // This is the bug task itself
+				return 2, nil // Bug task created successfully
+			}
+			return 0, repoError // Original task creation fails
+		}
+
+		_, err := taskService.CreateTask(ctx, "Another Task", "Desc", nil, nil)
+
+		if err == nil {
+			t.Errorf("Expected an error, got nil")
+		}
+		if !errors.Is(err, repoError) { // Check if original error is returned
+			t.Errorf("Expected error %v, got %v", repoError, err)
+		}
+
+		if len(mockRepo.CreatedBugTasks) == 0 {
+			t.Errorf("Expected a bug task to be created, but none found")
+		} else {
+			bugTask := mockRepo.CreatedBugTasks[0]
+			expectedBugTitle := "[BUG] Task Creation Failure"
+			if bugTask.Title != expectedBugTitle {
+				t.Errorf("Expected bug task title '%s', got '%s'", expectedBugTitle, bugTask.Title)
+			}
+			// Check description contains original error
+			if !strings.Contains(bugTask.Description, repoError.Error()) {
+				t.Errorf("Bug task description should contain original error '%s', got '%s'", repoError.Error(), bugTask.Description)
+			}
+		}
+	})
+
+	t.Run("validation error (empty title)", func(t *testing.T) {
+		mockRepo.CreatedBugTasks = []models.Task{} // Reset
+		_, err := taskService.CreateTask(ctx, "", "Desc", nil, nil)
+		if err == nil {
+			t.Errorf("Expected validation error for empty title, got nil")
+		}
+		if len(mockRepo.CreatedBugTasks) != 0 {
+			t.Errorf("Expected no bug tasks for validation error, got %d", len(mockRepo.CreatedBugTasks))
+		}
+	})
+}
+
+func TestTaskService_ListActiveTasksByClass(t *testing.T) {
+	mockRepo := &MockTaskRepository{}
+	taskService := NewTaskService(mockRepo)
+	ctx := context.Background()
+	classID := int64(1)
+
+	t.Run("successful listing", func(t *testing.T) {
+		mockRepo.CreatedBugTasks = []models.Task{}
+		mockTasks := []models.Task{
+			{ID: 1, Title: "Task 1", IsCompleted: false, ClassID: &classID},
+			{ID: 2, Title: "Task 2", IsCompleted: true, ClassID: &classID}, // Should be filtered out
+			{ID: 3, Title: "Task 3", IsCompleted: false, ClassID: &classID},
+		}
+		mockRepo.GetTasksByClassIDFunc = func(ctx context.Context, cID int64) ([]models.Task, error) {
+			if cID == classID {
+				return mockTasks, nil
+			}
+			return nil, fmt.Errorf("unexpected classID: %d", cID)
+		}
+
+		tasks, err := taskService.ListActiveTasksByClass(ctx, classID)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if len(tasks) != 2 {
+			t.Errorf("Expected 2 active tasks, got %d", len(tasks))
+		}
+		if tasks[0].Title != "Task 1" || tasks[1].Title != "Task 3" {
+			t.Errorf("Unexpected tasks returned: %+v", tasks)
+		}
+		if len(mockRepo.CreatedBugTasks) != 0 {
+			t.Errorf("Expected no bug tasks, got %d", len(mockRepo.CreatedBugTasks))
+		}
+	})
+
+	t.Run("repository error on listing", func(t *testing.T) {
+		mockRepo.CreatedBugTasks = []models.Task{}
+		repoError := errors.New("repo list error")
+		mockRepo.GetTasksByClassIDFunc = func(ctx context.Context, cID int64) ([]models.Task, error) {
+			return nil, repoError
+		}
+		// Simulate bug task creation success
+		mockRepo.CreateTaskFunc = func(ctx context.Context, task *models.Task) (int64, error) {
+			return 100, nil
+		}
+
+
+		_, err := taskService.ListActiveTasksByClass(ctx, classID)
+		if err == nil {
+			t.Errorf("Expected an error, got nil")
+		}
+		if !errors.Is(err, repoError) {
+			t.Errorf("Expected error %v, got %v", repoError, err)
+		}
+		if len(mockRepo.CreatedBugTasks) == 0 {
+			t.Errorf("Expected a bug task to be created")
+		} else if !strings.Contains(mockRepo.CreatedBugTasks[0].Title, "[BUG] Task Listing Failure") {
+			t.Errorf("Incorrect bug task title: %s", mockRepo.CreatedBugTasks[0].Title)
+		}
+	})
+}
+
+func TestTaskService_ListAllActiveTasks(t *testing.T) {
+	mockRepo := &MockTaskRepository{}
+	taskService := NewTaskService(mockRepo)
+	ctx := context.Background()
+
+	t.Run("successful listing all", func(t *testing.T) {
+		mockRepo.CreatedBugTasks = []models.Task{}
+		nilClassID := (*int64)(nil)
+		classID1 := int64(1)
+		mockTasks := []models.Task{
+			{ID: 1, Title: "Task 1", IsCompleted: false, ClassID: &classID1},
+			{ID: 2, Title: "System Task (Bug)", IsCompleted: false, ClassID: nilClassID, UserID: 0},
+			{ID: 3, Title: "Task 3 Completed", IsCompleted: true, ClassID: &classID1},
+		}
+		mockRepo.GetAllTasksFunc = func(ctx context.Context) ([]models.Task, error) {
+			return mockTasks, nil
+		}
+
+		tasks, err := taskService.ListAllActiveTasks(ctx)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if len(tasks) != 2 {
+			t.Errorf("Expected 2 active tasks, got %d (tasks: %+v)", len(tasks), tasks)
+		}
+		// Check titles to ensure correct tasks are returned
+		titles := []string{}
+		for _, task := range tasks {
+			titles = append(titles, task.Title)
+		}
+		if !contains(titles, "Task 1") || !contains(titles, "System Task (Bug)") {
+			t.Errorf("Expected 'Task 1' and 'System Task (Bug)', got %v", titles)
+		}
+
+		if len(mockRepo.CreatedBugTasks) != 0 {
+			t.Errorf("Expected no bug tasks, got %d", len(mockRepo.CreatedBugTasks))
+		}
+	})
+
+	t.Run("repository error on listing all", func(t *testing.T) {
+		mockRepo.CreatedBugTasks = []models.Task{}
+		repoError := errors.New("repo list all error")
+		mockRepo.GetAllTasksFunc = func(ctx context.Context) ([]models.Task, error) {
+			return nil, repoError
+		}
+		mockRepo.CreateTaskFunc = func(ctx context.Context, task *models.Task) (int64, error) { return 101, nil } // Bug task creation
+
+		_, err := taskService.ListAllActiveTasks(ctx)
+		if err == nil {
+			t.Errorf("Expected an error, got nil")
+		}
+		if !errors.Is(err, repoError) {
+			t.Errorf("Expected error %v, got %v", repoError, err)
+		}
+		if len(mockRepo.CreatedBugTasks) == 0 {
+			t.Errorf("Expected a bug task to be created")
+		} else if !strings.Contains(mockRepo.CreatedBugTasks[0].Title, "[BUG] Task Listing Failure") {
+			t.Errorf("Incorrect bug task title: %s", mockRepo.CreatedBugTasks[0].Title)
+		}
+	})
+}
+
+
+func TestTaskService_MarkTaskAsCompleted(t *testing.T) {
+	mockRepo := &MockTaskRepository{}
+	taskService := NewTaskService(mockRepo)
+	ctx := context.Background()
+	taskID := int64(1)
+
+	t.Run("successful completion", func(t *testing.T) {
+		mockRepo.CreatedBugTasks = []models.Task{}
+		mockRepo.MarkTaskCompletedFunc = func(ctx context.Context, tID int64) error {
+			if tID == taskID {
+				return nil
+			}
+			return fmt.Errorf("unexpected taskID: %d", tID)
+		}
+
+		err := taskService.MarkTaskAsCompleted(ctx, taskID)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if len(mockRepo.CreatedBugTasks) != 0 {
+			t.Errorf("Expected no bug tasks, got %d", len(mockRepo.CreatedBugTasks))
+		}
+	})
+
+	t.Run("repository error on completion", func(t *testing.T) {
+		mockRepo.CreatedBugTasks = []models.Task{}
+		repoError := errors.New("repo mark completed error")
+		mockRepo.MarkTaskCompletedFunc = func(ctx context.Context, tID int64) error {
+			return repoError
+		}
+		mockRepo.CreateTaskFunc = func(ctx context.Context, task *models.Task) (int64, error) { return 102, nil } // Bug task creation
+
+		err := taskService.MarkTaskAsCompleted(ctx, taskID)
+		if err == nil {
+			t.Errorf("Expected an error, got nil")
+		}
+		if !errors.Is(err, repoError) {
+			t.Errorf("Expected error %v, got %v", repoError, err)
+		}
+		if len(mockRepo.CreatedBugTasks) == 0 {
+			t.Errorf("Expected a bug task to be created")
+		} else if !strings.Contains(mockRepo.CreatedBugTasks[0].Title, "[BUG] Task Completion Failure") {
+			t.Errorf("Incorrect bug task title: %s", mockRepo.CreatedBugTasks[0].Title)
+		}
+	})
+}
+
+
+// Helper function
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+// Helper function to set up a temporary DB for tests that might need it (though most use mocks)
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	// Use in-memory SQLite for testing; ensure a unique name if tests run in parallel
+	// or ensure cleanup. For simple sequential tests, "file::memory:" is often fine.
+	// For parallel, "file::memory:?cache=shared" or unique temp files.
+	db, err := sql.Open("sqlite3", "file::memory:?cache=shared")
+	if err != nil {
+		t.Fatalf("Failed to open in-memory database: %v", err)
+	}
+
+	// Run migrations if your stubs or actual repositories need the schema
+	schema, err := os.ReadFile("../../internal/database/migrations/001_initial_schema.sql")
+	if err != nil {
+		db.Close()
+		t.Fatalf("Failed to read schema file: %v", err)
+	}
+	_, err = db.Exec(string(schema))
+	if err != nil {
+		db.Close()
+		t.Fatalf("Failed to apply schema: %v", err)
+	}
+
+	return db
+}
+
+func TestMain(m *testing.M) {
+	// Setup tasks before running tests, e.g., DB connection or loading config
+	// For these tests, we primarily use mocks, so global setup might not be strictly needed here.
+	// However, if any test relies on a real DB (even sqlite in-memory for stubs),
+	// it could be initialized here or per-test.
+
+	exitCode := m.Run()
+
+	// Teardown tasks after tests are done
+	os.Exit(exitCode)
+}
+// Add import for strings at the top of the file
+// import "strings"


### PR DESCRIPTION
This commit introduces the initial framework for monitoring system errors and automatically creating tasks for them.

Key changes:
- Defined "Bug Report System Monitoring" to involve logging errors and creating special '[BUG]' tasks.
- Enhanced `internal/service/task_service.go`:
    - Added `logError` for standardized error logging to stderr.
    - Implemented `handleErrorAndCreateBugTask` which uses the `TaskRepository` to create a task when a significant error occurs.
    - Modified existing service methods (`CreateTask`, `ListActiveTasksByClass`, `MarkTaskAsCompleted`) to call `handleErrorAndCreateBugTask` on repository failures.
    - Added `ListAllActiveTasks` to fetch all tasks, including system/bug tasks.
- Updated `internal/repository/repository.go` and `internal/repository/stubs.go`:
    - Defined the `TaskRepository` interface with necessary methods.
    - `StubTaskRepository` implements these methods, including `GetAllTasks`.
- Updated `cmd/vigenda/main.go`:
    - The `tarefa listar` command now supports an `--all` flag to display all tasks, making bug tasks visible.
    - Task service is now initialized with `service.NewTaskService` instead of the stub.
- Added `internal/service/task_service_test.go` with unit tests for `TaskService` methods, including checks for bug task creation.
- Updated `internal/service/stubs.go` to ensure `stubTaskService` implements the full `TaskService` interface.

Current Status:
The unit tests for `task_service_test.go` are currently failing with an "imported and not used" error for the `vigenda/internal/repository` package, despite the `MockTaskRepository` within the test file appearing to use types that would necessitate this import (e.g., `models.Task` which is used by repository methods). I was in the process of diagnosing this specific test error. The `task_service.go` file itself also had an "undefined: repository" error which was fixed by adding the correct import.

Next steps were intended to be resolving the test error, performing a full build and manual test, and then submitting.