### PR TITLE
Define e documenta processo de bug tracking e melhora logging de bugs…

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,3 +211,7 @@ Este projeto é atualmente mantido para um propósito específico. No entanto, s
 ## Licença
 
 Este projeto não possui uma licença de código aberto definida no momento. Todos os direitos são reservados.
+
+## Reporte de Bugs
+
+Para informações sobre como reportar bugs, como eles são analisados e gerenciados, por favor consulte o arquivo [BUG_REPORTING.md](BUG_REPORTING.md).

--- a/cmd/vigenda/main.go
+++ b/cmd/vigenda/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/charmbracelet/bubbles/table"
 	"github.com/spf13/cobra"
 	"vigenda/internal/database"
+	"vigenda/internal/models" // Added import for models package
 	"vigenda/internal/repository"
 	"vigenda/internal/service"
 	"vigenda/internal/tui"

--- a/internal/service/task_service.go
+++ b/internal/service/task_service.go
@@ -39,8 +39,8 @@ func (s *taskServiceImpl) handleErrorAndCreateBugTask(ctx context.Context, origi
 	// O UserID para tarefas de sistema/bug pode ser um valor especial (ex: 0 ou um ID de usuário de sistema configurado)
 	// ou podemos omiti-lo se o modelo permitir. Assumindo que UserID 0 é para tarefas do sistema.
 	// ClassID pode ser nil se o bug não for específico de uma turma.
-	bugTitle := fmt.Sprintf("[BUG] %s", bugTitlePrefix)
-	bugDescription := fmt.Sprintf("Error encountered: %v. Details: %s", originalError, fmt.Sprintf(bugDescriptionArgs[0].(string), bugDescriptionArgs[1:]...))
+	bugTitle := fmt.Sprintf("[BUG][AUTO][PRIORITY_PENDING] %s", bugTitlePrefix)
+	bugDescription := fmt.Sprintf("[PRIORITY_PENDING] Error encountered: %v. Details: %s", originalError, fmt.Sprintf(bugDescriptionArgs[0].(string), bugDescriptionArgs[1:]...))
 
 	// O UserID para tarefas de sistema/bug pode ser um valor especial (ex: 0 ou um ID de usuário de sistema configurado)
 	// Usaremos UserID 0 para tarefas do sistema. ClassID pode ser nil.


### PR DESCRIPTION
… automáticos

TASK-M-01: Monitorizar o sistema de reporte de bugs. Analisar, priorizar e criar novas tarefas de correção.

Este commit introduz:
- Um novo arquivo `BUG_REPORTING.md` que detalha o processo para reportar, analisar, priorizar e transformar bugs em tarefas de correção dentro do Vigenda.
- Uma referência a `BUG_REPORTING.md` no `README.md`.
- Uma pequena modificação na função `handleErrorAndCreateBugTask` em `internal/service/task_service.go` para que os bugs criados automaticamente tenham os prefixos `[AUTO]` e `[PRIORITY_PENDING]` no título e na descrição, facilitando a triagem e alinhando com o processo documentado.
- Correção de uma importação ausente do pacote `models` em `cmd/vigenda/main.go` que impedia a compilação.