### PR TITLE
Fix: Resolve schema path relative to executable

### DIFF
--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings" // Added import for strings.Join
 
 	_ "github.com/mattn/go-sqlite3" // SQLite driver
 )
@@ -37,42 +38,43 @@ func GetDBConnection(dataSourceName string) (*sql.DB, error) {
 	defer rows.Close()
 
 	if !rows.Next() { // If 'users' table doesn't exist, apply schema
-		// Attempt to find schema relative to executable if running built binary,
-		// or relative to project structure if running with 'go run'.
-		// This path needs to be robust. For tests, it's relative to test execution.
-		// For the actual app, it's relative to the binary or `go run` CWD.
+		var schemaBytes []byte
+		var readErr error
+		var attemptedPaths []string
 
-		// Try to determine the correct path to the schema file.
-		// This is tricky because the CWD changes depending on how the app is run.
-		// For `go test ./...` from project root, `internal/database/migrations/...` would be accessible.
-		// For the built binary, it might need to be bundled or placed in a known relative path.
+		// Path 1: Relative to executable (for distributed binary)
+		execPath, err := os.Executable()
+		if err == nil {
+			execDir := filepath.Dir(execPath)
+			schemaPathFromExec := filepath.Join(execDir, "..", "internal", "database", "migrations", "001_initial_schema.sql")
+			attemptedPaths = append(attemptedPaths, schemaPathFromExec)
+			schemaBytes, readErr = os.ReadFile(schemaPathFromExec)
+		}
 
-		// Simplified approach: Assume schema is in a known relative path from CWD
-		// This might need adjustment based on build/deployment structure.
-		// Let's assume CWD is project root when running `go run cmd/vigenda/main.go`
-		// or when tests run the binary (tests set their own CWD or binary is in temp dir).
+		// Path 2: Relative to CWD (for 'go run' from project root)
+		if readErr != nil {
+			schemaPathFromCwd := "internal/database/migrations/001_initial_schema.sql"
+			attemptedPaths = append(attemptedPaths, schemaPathFromCwd)
+			schemaBytes, readErr = os.ReadFile(schemaPathFromCwd)
+		}
 
-		// Path from project root: internal/database/migrations/001_initial_schema.sql
-		primarySchemaPath := "internal/database/migrations/001_initial_schema.sql"
-		// Fallback for tests where CWD might be e.g. tests/integration, or if binary is in a different relative location.
-		alternativeSchemaPath := filepath.Join("..", "..", "internal", "database", "migrations", "001_initial_schema.sql")
+		// Path 3: Fallback relative path (for tests or other structures)
+		if readErr != nil {
+			alternativeSchemaPath := filepath.Join("..", "..", "internal", "database", "migrations", "001_initial_schema.sql")
+			attemptedPaths = append(attemptedPaths, alternativeSchemaPath)
+			schemaBytes, readErr = os.ReadFile(alternativeSchemaPath)
+		}
 
-		schemaBytes, err := os.ReadFile(primarySchemaPath)
-		if err != nil {
-			// Try alternative path
-			schemaBytes, err = os.ReadFile(alternativeSchemaPath)
-			if err != nil {
-				db.Close()
-				return nil, fmt.Errorf("failed to read schema file at %s or %s: %w", primarySchemaPath, alternativeSchemaPath, err)
-			}
+		if readErr != nil {
+			db.Close()
+			// Use strings.Join for better readability of attempted paths in the error message
+			return nil, fmt.Errorf("failed to read schema file. Attempted paths: [%s]. Last error: %w", strings.Join(attemptedPaths, ", "), readErr)
 		}
 
 		_, err = db.Exec(string(schemaBytes))
 		if err != nil {
 			db.Close()
-			// The error message here could refer to primarySchemaPath or alternativeSchemaPath
-			// depending on which one was successfully read. For simplicity, just state the action failed.
-			return nil, fmt.Errorf("failed to apply initial schema (tried %s and %s): %w", primarySchemaPath, alternativeSchemaPath, err)
+			return nil, fmt.Errorf("failed to apply initial schema (tried paths: [%s]): %w", strings.Join(attemptedPaths, ", "), err)
 		}
 		// fmt.Println("Database schema initialized.") // Removed noisy print
 	}


### PR DESCRIPTION
When running the compiled binary from the dist/ directory, the application was unable to find the database schema file (001_initial_schema.sql) because it was using hardcoded relative paths (internal/... or ../../internal/...) that were incorrect from the binary's location.

This commit updates internal/database/connection.go to:
- Determine the path to the currently running executable.
- Attempt to load the schema file from a path relative to the executable's directory (e.g., execDir/../internal/database/migrations/schema.sql).
- Fall back to the previous CWD-relative paths if the executable-relative path fails (useful for `go run` or tests).
- Improves error messaging to show all attempted paths if the schema file cannot be loaded.