### PR TITLE
feat: Implement core BubbleTea application shell

### DIFF
--- a/cmd/vigenda/main.go
+++ b/cmd/vigenda/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/table" // Reativado para columns e rows
 	"github.com/spf13/cobra"
+	"vigenda/internal/app" // Import for the new BubbleTea app
 	"vigenda/internal/database"
 	"vigenda/internal/models" // Added import for models package
 	"vigenda/internal/repository"
@@ -45,24 +46,10 @@ Funcionalidades Principais:
 
 Use "vigenda [comando] --help" para mais informações sobre um comando específico.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// This is the main dashboard view
-		// For now, printing a simplified version.
-		// TODO: Implement actual data fetching and formatting as per golden file.
-		fmt.Println("=================================================")
-		fmt.Println("==                 DASHBOARD                   ==")
-		fmt.Println("=================================================")
-		fmt.Println("")
-		fmt.Println("🕒 AGENDA DE HOJE (22/06/2025)")
-		fmt.Println("   [09:00 - 10:00] Aula de História - Turma 9A")
-		fmt.Println("   [14:00 - 15:00] Reunião Pedagógica")
-		fmt.Println("")
-		fmt.Println("🔥 TAREFAS PRIORITÁRIAS")
-		fmt.Println("   [1] Corrigir provas (Turma 9A) (Prazo: Amanhã)")
-		fmt.Println("   [2] Preparar aula sobre Era Vargas (Turma 9B) (Prazo: 24/06)")
-		fmt.Println("")
-		fmt.Println("🔔 NOTIFICAÇÕES")
-		fmt.Println("   - 5 entregas pendentes para o trabalho \"Pesquisa sobre Clima\" (Turma 9A).")
-		fmt.Println("") // Ensure a trailing newline if the golden file has one after trimming
+		// Launch the BubbleTea application
+		// Ensure services are initialized if BubbleTea app needs them immediately.
+		// The PersistentPreRunE should handle DB and service initialization.
+		app.StartApp()
 	},
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// This function will run before any command, ensuring DB is initialized.

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
@@ -51,6 +53,8 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=
+github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,0 +1,176 @@
+package app
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+var (
+	appStyle = lipgloss.NewStyle().Padding(1, 2)
+	// Define other styles as needed
+)
+
+// Model represents the main application model.
+type Model struct {
+	list         list.Model
+	currentView  View
+	width        int
+	height       int
+	quitting     bool
+	err          error // To store any critical errors for display
+	// Potentially, sub-models for different views will be added here
+	// e.g., tasksModel tasks.Model
+}
+
+// Init initializes the application model.
+func (m Model) Init() tea.Cmd {
+	return nil // No initial command
+}
+
+// New creates a new instance of the application model.
+func New() Model {
+	// Define menu items using the View enum for safer mapping
+	menuItems := []list.Item{
+		menuItem{title: DashboardView.String(), view: DashboardView}, // Dashboard is the menu itself
+		menuItem{title: TaskManagementView.String(), view: TaskManagementView},
+		menuItem{title: ClassManagementView.String(), view: ClassManagementView},
+		menuItem{title: AssessmentManagementView.String(), view: AssessmentManagementView},
+		menuItem{title: QuestionBankView.String(), view: QuestionBankView},
+		menuItem{title: ProofGenerationView.String(), view: ProofGenerationView},
+	}
+
+	l := list.New(menuItems, list.NewDefaultDelegate(), 0, 0)
+	l.Title = "Vigenda - Menu Principal"
+	l.SetShowStatusBar(false)
+	l.SetFilteringEnabled(false)
+	l.Styles.Title = lipgloss.NewStyle().Bold(true).MarginBottom(1)
+	l.AdditionalShortHelpKeys = func() []key.Binding {
+		return []key.Binding{
+			key.NewBinding(key.WithKeys("q", "ctrl+c"), key.WithHelp("q/ctrl+c", "sair")),
+			key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "selecionar")),
+		}
+	}
+	l.AdditionalFullHelpKeys = l.AdditionalShortHelpKeys // Keep it simple for now
+
+	return Model{
+		list:        l,
+		currentView: DashboardView, // Start with the main menu
+	}
+}
+
+// menuItem holds the title and the corresponding view for a menu entry.
+type menuItem struct {
+	title string
+	view  View
+}
+
+func (i menuItem) FilterValue() string { return i.title }
+func (i menuItem) Title() string       { return i.title }
+func (i menuItem) Description() string { return "" } // Could add descriptions later
+
+// Update handles messages and updates the model.
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		// Adjust list size, leaving space for title and help
+		m.list.SetSize(msg.Width-appStyle.GetHorizontalPadding(), msg.Height-appStyle.GetVerticalPadding()-lipgloss.Height(m.list.Title)-2)
+		return m, nil
+
+	case tea.KeyMsg:
+		// Global keybindings
+		if key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+c"))) {
+			m.quitting = true
+			return m, tea.Quit
+		}
+
+		// View-specific keybindings
+		switch m.currentView {
+		case DashboardView: // Main Menu
+			switch {
+			case key.Matches(msg, key.NewBinding(key.WithKeys("q"))):
+				m.quitting = true
+				return m, tea.Quit
+			case key.Matches(msg, key.NewBinding(key.WithKeys("enter"))):
+				selectedItem, ok := m.list.SelectedItem().(menuItem)
+				if ok {
+					// DashboardView itself is the menu, so selecting it does nothing new
+					// or could refresh a dashboard if it were more complex.
+					// For other items, switch the view.
+					if selectedItem.view != DashboardView {
+						m.currentView = selectedItem.view
+						// Here you might load data or initialize the sub-model for the new view
+						// For now, just switching the view enum is enough for placeholder views.
+					}
+				}
+				return m, nil
+			}
+			m.list, cmd = m.list.Update(msg) // Update the list component
+		default: // Other views (TaskManagementView, ClassManagementView, etc.)
+			if key.Matches(msg, key.NewBinding(key.WithKeys("esc", "q"))) {
+				// Go back to the main menu from any other view
+				m.currentView = DashboardView
+				// You might want to reset the state of the sub-view here
+				return m, nil
+			}
+			// Later, pass messages to sub-models:
+			// switch m.currentView {
+			// case TaskManagementView:
+			//   m.tasksModel, cmd = m.tasksModel.Update(msg)
+			// }
+		}
+
+	case error:
+		m.err = msg
+		return m, nil
+	}
+	return m, cmd
+}
+
+// View renders the application's UI.
+func (m Model) View() string {
+	if m.quitting {
+		return appStyle.Render("Saindo do Vigenda...\n")
+	}
+	if m.err != nil {
+		return appStyle.Render(fmt.Sprintf("Ocorreu um erro: %v\nPressione 'q' para sair ou 'esc' para voltar ao menu.", m.err))
+	}
+
+	var viewContent string
+
+	switch m.currentView {
+	case DashboardView: // Main Menu
+		viewContent = m.list.View()
+	default: // Placeholder for other views
+		viewContent = fmt.Sprintf("Você está na visão: %s\n\nPressione 'esc' ou 'q' para voltar ao menu principal.", m.currentView.String())
+	}
+
+	// Basic help footer
+	help := "\nNavegue com ↑/↓, selecione com Enter."
+	if m.currentView != DashboardView {
+		help = "\nPressione 'esc' ou 'q' para voltar ao menu."
+	}
+
+
+	return appStyle.Render(lipgloss.JoinVertical(lipgloss.Left,
+		viewContent,
+		lipgloss.NewStyle().MarginTop(1).Render(help),
+	))
+}
+
+// StartApp is a helper to run the BubbleTea program.
+func StartApp() {
+	p := tea.NewProgram(New(), tea.WithAltScreen()) // Using AltScreen is common for TUIs
+	if _, err := p.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Erro ao executar o Vigenda TUI: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,0 +1,162 @@
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss" // Added missing import
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewModel_InitialState(t *testing.T) {
+	m := New()
+	assert.Equal(t, DashboardView, m.currentView, "Initial view should be DashboardView")
+	require.Greater(t, m.list.Index(), -1, "List should have items") // list.Items() is not public
+	assert.Contains(t, m.list.Items()[0].(menuItem).Title(), DashboardView.String(), "First item should be Dashboard")
+}
+
+func TestModel_Update_Quit(t *testing.T) {
+	m := New()
+	// Test 'q' from DashboardView
+	qMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}}
+	nextModel, cmd := m.Update(qMsg)
+	assert.True(t, nextModel.(Model).quitting, "Model should be quitting on 'q'")
+	assert.NotNil(t, cmd, "A command (tea.Quit) should be returned on 'q'") // Check cmd is not nil
+
+	// Test 'ctrl+c'
+	m = New() // Reset model
+	ctrlCMsg := tea.KeyMsg{Type: tea.KeyCtrlC}
+	nextModel, cmd = m.Update(ctrlCMsg)
+	assert.True(t, nextModel.(Model).quitting, "Model should be quitting on 'ctrl+c'")
+	assert.NotNil(t, cmd, "A command (tea.Quit) should be returned on 'ctrl+c'") // Check cmd is not nil
+}
+
+func TestModel_Update_NavigateToSubViewAndBack(t *testing.T) {
+	m := New()
+	initialView := m.currentView
+
+	// Simulate selecting the second item (TaskManagementView)
+	m.list.Select(1) // Select "Gerenciar Tarefas"
+	enterMsg := tea.KeyMsg{Type: tea.KeyEnter}
+	nextModel, _ := m.Update(enterMsg)
+	m = nextModel.(Model)
+
+	assert.Equal(t, TaskManagementView, m.currentView, "View should change to TaskManagementView on Enter")
+
+	// Simulate pressing 'esc' to go back
+	escMsg := tea.KeyMsg{Type: tea.KeyEsc}
+	nextModel, _ = m.Update(escMsg)
+	m = nextModel.(Model)
+
+	assert.Equal(t, initialView, m.currentView, "View should change back to DashboardView on Esc")
+
+	// Simulate pressing 'q' from subview to go back
+	m.currentView = TaskManagementView // Go to subview again
+	qMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}}
+	nextModel, _ = m.Update(qMsg)
+	m = nextModel.(Model)
+	assert.Equal(t, initialView, m.currentView, "View should change back to DashboardView on 'q' from subview")
+
+}
+
+func TestModel_View_Content(t *testing.T) {
+	m := New()
+	// Set initial size for consistent rendering of the list
+	updatedModel, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updatedModel.(Model)
+
+	// Initial view (Dashboard/Menu)
+	viewOutput := m.View()
+	assert.Contains(t, viewOutput, m.list.Title, "View should contain list title in DashboardView")
+	assert.Contains(t, viewOutput, "Navegue com ↑/↓", "View should contain help text for menu")
+
+
+	// Navigate to a sub-view
+	m.list.Select(1) // "Gerenciar Tarefas"
+	enterMsg := tea.KeyMsg{Type: tea.KeyEnter}
+	nextModel, _ := m.Update(enterMsg)
+	m = nextModel.(Model)
+
+	viewOutput = m.View()
+	expectedSubstring := "Você está na visão: " + TaskManagementView.String()
+	assert.Contains(t, viewOutput, expectedSubstring, "View should show placeholder for TaskManagementView")
+	assert.Contains(t, viewOutput, "Pressione 'esc' ou 'q' para voltar", "View should contain help text for subview")
+
+}
+
+func TestModel_Update_WindowSize(t *testing.T) {
+	m := New()
+	newWidth, newHeight := 80, 24
+	sizeMsg := tea.WindowSizeMsg{Width: newWidth, Height: newHeight}
+	nextModel, _ := m.Update(sizeMsg)
+	m = nextModel.(Model)
+
+	assert.Equal(t, newWidth, m.width, "Model width should be updated")
+	assert.Equal(t, newHeight, m.height, "Model height should be updated")
+	// Check if list size was also updated (approximate check)
+	// This depends on internal calculations of list.SetSize
+	// We know appStyle padding is 1,2. Vertical padding 2. Title height 1. Help text height 1. Total 4.
+	// list.SetSize(msg.Width-appStyle.GetHorizontalPadding(), msg.Height-appStyle.GetVerticalPadding()-lipgloss.Height(m.list.Title)-2)
+	// Horizontal padding is 2*2 = 4. So list width = 80 - 4 = 76
+	// Vertical padding is 1*2 = 2. Title height = 1 (title + margin). Help text = 1. Total elements to subtract = 2 + 1 + 1 = 4
+	// So list height = 24 - (appStyle vertical padding: 2) - (title height with margin: 2) - (help text: 1) = 24 - 2 - 2 -1 = 19
+	// Actually, it's msg.Height-appStyle.GetVerticalPadding()-lipgloss.Height(m.list.Title)-2
+	// msg.Height - 2 - 2 - 2 = 18. Let's recheck lipgloss.Height(m.list.Title)
+	// m.list.Title is "Vigenda - Menu Principal". l.Styles.Title has MarginBottom(1). So height is 2.
+	// So, msg.Height (24) - appStyle.GetVerticalPadding() (2) - lipgloss.Height(m.list.Title) (2) - 2 (for help text and general spacing) = 18
+	assert.Equal(t, newWidth-appStyle.GetHorizontalPadding(), m.list.Width(), "List width should be updated based on window size")
+	assert.Equal(t, newHeight-appStyle.GetVerticalPadding()-lipgloss.Height(m.list.Title)-2, m.list.Height(), "List height should be updated based on window size")
+}
+
+func TestMenuItem_Interface(t *testing.T) {
+	item := menuItem{title: "Test Title", view: DashboardView}
+	assert.Equal(t, "Test Title", item.Title())
+	assert.Equal(t, "Test Title", item.FilterValue()) // FilterValue currently returns title
+	assert.Equal(t, "", item.Description()) // Description is empty
+}
+
+func TestView_String(t *testing.T) {
+	assert.Equal(t, "Dashboard", DashboardView.String())
+	assert.Equal(t, "Gerenciar Tarefas", TaskManagementView.String())
+	// Add more if new views are added and string representations are critical
+}
+
+// Helper to simulate a key press
+func simulateKeyPress(m tea.Model, key rune) (tea.Model, tea.Cmd) {
+	return m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{key}})
+}
+
+// Helper to simulate an Enter key press
+func simulateEnterPress(m tea.Model) (tea.Model, tea.Cmd) {
+	return m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+}
+
+// Helper to simulate an Esc key press
+func simulateEscPress(m tea.Model) (tea.Model, tea.Cmd) {
+	return m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+}
+
+// Helper for Ctrl+C
+func simulateCtrlCPress(m tea.Model) (tea.Model, tea.Cmd) {
+	return m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+}
+
+// Example of using helpers (can be expanded into actual tests)
+func TestModel_Update_WithHelpers(t *testing.T) {
+	m := New()
+
+	// Select second item ("Gerenciar Tarefas")
+	m.list.Select(1)
+	nextModel, _ := simulateEnterPress(m)
+	m = nextModel.(Model)
+	assert.Equal(t, TaskManagementView, m.currentView)
+
+	nextModel, _ = simulateEscPress(m)
+	m = nextModel.(Model)
+	assert.Equal(t, DashboardView, m.currentView)
+
+	nextModel, cmd := simulateCtrlCPress(m)
+	assert.True(t, nextModel.(Model).quitting)
+	assert.NotNil(t, cmd) // Check that tea.Quit (a non-nil cmd) is returned
+}

--- a/internal/app/views.go
+++ b/internal/app/views.go
@@ -1,0 +1,25 @@
+package app
+
+// View represents the current active view/module in the TUI.
+type View int
+
+const (
+	DashboardView View = iota
+	TaskManagementView
+	ClassManagementView
+	AssessmentManagementView
+	QuestionBankView
+	ProofGenerationView
+	// Add other views as needed
+)
+
+func (v View) String() string {
+	return [...]string{
+		"Dashboard",
+		"Gerenciar Tarefas",
+		"Gerenciar Turmas e Alunos",
+		"Gerenciar Avaliações e Notas",
+		"Banco de Questões",
+		"Gerar Provas",
+	}[v]
+}


### PR DESCRIPTION
Introduces the initial BubbleTea TUI structure.

- Adds BubbleTea, Bubbles, and Lipgloss dependencies.
- Creates a new `internal/app` package for the main TUI application.
- Implements `app.Model` with `Init`, `Update`, and `View` methods.
- The TUI launches with a main menu (DashboardView) allowing navigation to placeholder views for Tasks, Classes, Assessments, Question Bank, and Proof Generation.
- Users can navigate back to the main menu from placeholder views using 'esc' or 'q'.
- Global quit ('ctrl+c') and main menu quit ('q') are functional.
- `cmd/vigenda/main.go` is updated to launch this TUI when no subcommands are provided.
- Basic unit tests for the app navigation shell are included and passing.