### PR TITLE
Fix: Esc key not returning to main menu from Gerar Provas view

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -14,7 +14,9 @@ import (
 	"vigenda/internal/app/proofs"      // Import for the proofs module
 	"vigenda/internal/app/questions"   // Import for the questions module
 	"vigenda/internal/app/tasks"       // Import for the tasks module
-	"vigenda/internal/service"         // Import for service interfaces
+	"vigenda/internal/service" // Import for service interfaces
+	// Ensure proofs package is imported if not already, for GoBackToDashboardMsg
+	// "vigenda/internal/app/proofs" // This line might already exist or be handled by goimports
 )
 
 var (
@@ -204,6 +206,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Default case for the first switch: if the msg type wasn't WindowSizeMsg, KeyMsg (for dashboard), or error,
 		// it will fall through to the submodel delegation logic.
+
+	case proofs.GoBackToDashboardMsg: // Handle message from proofs model
+		m.currentView = DashboardView
+		log.Println("AppModel: Voltando para DashboardView a partir de ProofGenerationView (via GoBackToDashboardMsg).")
+		// Optional: Reset list selection or other dashboard state if necessary
+		// m.list.ResetFilter()
+		// m.list.ResetSelected()
+		return m, nil // No further command needed from here for this action
 	}
 
 	// Second stage: Delegate message to the active submodel if not handled above

--- a/internal/app/proofs/model.go
+++ b/internal/app/proofs/model.go
@@ -51,6 +51,9 @@ type proofGeneratedMsg struct {
 	err   error
 }
 
+// GoBackToDashboardMsg signals the main app model to switch to the dashboard view.
+type GoBackToDashboardMsg struct{}
+
 // --- Cmds ---
 func (m *Model) generateProofCmd() tea.Cmd {
 	subjectIDStr := m.textInputs[0].Value()
@@ -159,8 +162,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// No need to explicitly return focus cmd here as resetForm handles it.
 				return m, nil // Return m directly
 			}
-			// If in FormView, Esc is handled by parent model to go to main menu
-			return m, nil // Return m directly
+			// If in FormView, signal parent to go back to the dashboard
+			cmds = append(cmds, func() tea.Msg { return GoBackToDashboardMsg{} })
+			return m, tea.Batch(cmds...)
 		}
 
 		switch m.state {


### PR DESCRIPTION
Implemented a fix to ensure that pressing the 'Esc' key while in the 'Gerar Provas' (ProofGenerationView) form correctly navigates back to the main menu (DashboardView).

Changes:
- Defined a new `GoBackToDashboardMsg` in the proofs model.
- Modified `proofs.Model.Update` to emit this message when 'Esc' is pressed in `FormView`.
- Updated `app.Model.Update` to handle `GoBackToDashboardMsg` by switching the current view to `DashboardView`.

This ensures that the 'Esc' key functions as expected for returning to the main menu, while internal navigation within the 'Gerar Provas' module (e.g., 'Esc' from proof display to form) remains unaffected.